### PR TITLE
Priority設定で不正な値でエラーにならないように

### DIFF
--- a/unreal_engine_plugin/LiveStreaming_ClientSDK/Source/ThirdParty/Include/ClassDefine.h
+++ b/unreal_engine_plugin/LiveStreaming_ClientSDK/Source/ThirdParty/Include/ClassDefine.h
@@ -431,7 +431,7 @@ public:
 	enum class SendingPriority 
 	{
 		isNull = -999,
-		Normal,
+		Normal = 0,
 		High,
 	};
 


### PR DESCRIPTION
Priority設定時に不正な値でエラーなるので対応しました